### PR TITLE
Add ability to autodiscover, or explicitly pass application version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ You need to configure NLog.config.
 * IgnoreServerVariableNames - Server vars you wish to ignore, eg sessions
 * IgnoreHeaderNames - HTTP header to ignore, eg API keys
 * UseIdentityNameAsUserId - If you're using a web project, send user name from HttpContext.Current.User.Identity.Name? Used for User Tracking
-
+* UseExecutingAssemblyVersion - Attempt to get the executing assembly version, or root ASP.Net assembly version for Raygun events.
+* ApplicationVersion - Explicitly defines an application version for Raygun events. This will be ignored if UseExecutingAssemblyVersion is set to true and returns a value.
+    
 ### NLog Configuration
 
 Your `NLog.config` should look something like this:
@@ -46,6 +48,8 @@ Your `NLog.config` should look something like this:
 				IgnoreServerVariableNames="" 
         IgnoreHeaderNames=""
         UseIdentityNameAsUserId="true"
+        UseExecutingAssemblyVersion="false"
+        ApplicationVersion=""
 				layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}"
       />
 	 </target>

--- a/src/NLog.Raygun.TestApp/NLog.config
+++ b/src/NLog.Raygun.TestApp/NLog.config
@@ -20,6 +20,9 @@
           IgnoreCookieNames=""
           IgnoreServerVariableNames=""
           IgnoreHeaderNames=""
+          UseIdentityNameAsUserId="false"
+          UseExecutingAssemblyVersion="false"
+          ApplicationVersion=""
           layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}"
         />
     </target>

--- a/src/NLog.Raygun.WebTestApp/NLog.config
+++ b/src/NLog.Raygun.WebTestApp/NLog.config
@@ -21,6 +21,9 @@
           IgnoreCookieNames=""
           IgnoreServerVariableNames=""
           IgnoreHeaderNames=""
+          UseIdentityNameAsUserId="false"
+          UseExecutingAssemblyVersion="false"
+          ApplicationVersion=""
           layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}"
         />
     </target>

--- a/src/NLog.Raygun/RayGunTarget.cs
+++ b/src/NLog.Raygun/RayGunTarget.cs
@@ -175,9 +175,9 @@ namespace NLog.Raygun
           {
             type = type.BaseType;
           }
-          assembly = type?.Assembly;
+          assembly = type != null ? type.Assembly : null;
         }
-        return assembly?.GetName().Version.ToString();
+        return assembly != null ? assembly.GetName().Version.ToString() : null;
 
       }
       catch (Exception)

--- a/src/NLog.Raygun/RayGunTarget.cs
+++ b/src/NLog.Raygun/RayGunTarget.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Web.Mvc;
 using Mindscape.Raygun4Net;
 using NLog.Config;
@@ -31,6 +32,18 @@ namespace NLog.Raygun
 
     [RequiredParameter]
     public bool UseIdentityNameAsUserId { get; set; }
+
+    /// <summary>
+    /// Attempt to get the executing assembly version, or root ASP.Net assembly version for Raygun events.
+    /// </summary>
+    [RequiredParameter]
+    public bool UseExecutingAssemblyVersion { get; set; }
+
+    /// <summary>
+    /// Explicitly defines an application version for Raygun events. 
+    /// NOTE: This value will be ignored if UseExecutingAssemblyVersion is set to true and returns a value.
+    /// </summary>
+    public string ApplicationVersion { get; set; }
 
     protected override void Write(LogEventInfo logEvent)
     {
@@ -108,11 +121,20 @@ namespace NLog.Raygun
     {
       var client = new RaygunClient(ApiKey);
 
+      if (UseExecutingAssemblyVersion)
+      {
+        client.ApplicationVersion = GetExecutingAssemblyVersion();
+      }
+
+      if (string.IsNullOrEmpty(client.ApplicationVersion))
+      {
+        client.ApplicationVersion = ApplicationVersion;
+      }
+
       client.IgnoreFormFieldNames(SplitValues(IgnoreFormFieldNames));
       client.IgnoreCookieNames(SplitValues(IgnoreCookieNames));
       client.IgnoreHeaderNames(SplitValues(IgnoreHeaderNames));
       client.IgnoreServerVariableNames(SplitValues(IgnoreServerVariableNames));
-
       return client;
     }
 
@@ -139,6 +161,30 @@ namespace NLog.Raygun
       }
 
       return new[] { string.Empty };
+    }
+
+    private static string GetExecutingAssemblyVersion()
+    {
+      try
+      {
+        var assembly = Assembly.GetEntryAssembly();
+        if (assembly == null)
+        {
+          var type = System.Web.HttpContext.Current.ApplicationInstance.GetType();
+          while (type != null && type.Namespace == "ASP")
+          {
+            type = type.BaseType;
+          }
+          assembly = type?.Assembly;
+        }
+        return assembly?.GetName().Version.ToString();
+
+      }
+      catch (Exception)
+      {
+        return null;
+      }
+
     }
   }
 }


### PR DESCRIPTION
I have been using the NLog.Raygun NuGet package recently and found myself wanting an ability to specify application version in the adapter configuration. I have provided two options:
- Automatically detect the application version from an executing assembly (command line app, etc), or the first non ASP.Net assembly (web app).
- Explicitly specify an ApplicationVersion in the NLog configuration.

I updated the README.md and examples.
