### PR TITLE
Added support for UserIdentityInfo for NetCore, and context-properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+; Top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = CRLF
+
+; 4-column space indentation
+[*.cs]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You need to configure NLog.config.
 
 * ApiKey - Your API key.
 * Tags - Tags you want to send in with every exception.
+* IncludeEventProperties - Include properties from NLog LogEvent. Default is ```true```.
+* IncludeMdlc - Include properties from NLog Mapped Diagnostic Logical Context (MDLC). Default is ```false```.
 * IgnoreFormFieldNames - Form fields you wish to ignore, eg passwords and credit cards.
 * IgnoreCookieNames - Cookies you wish to ignore, eg user tokens.
 * IgnoreServerVariableNames - Server variables you wish to ignore, eg sessions.
@@ -43,6 +45,7 @@ Your `NLog.config` should look something like this:
 		type="RayGun" 
 		ApiKey="" 
 		Tags="" 
+		IncludeEventProperties="true" 
 		IgnoreFormFieldNames="" 
 		IgnoreCookieNames="" 
 		IgnoreServerVariableNames="" 
@@ -50,8 +53,12 @@ Your `NLog.config` should look something like this:
 		UserIdentityInfo="" 
 		UseExecutingAssemblyVersion="false" 
 		ApplicationVersion="" 
-		layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}"
-      />
+		layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}">
+		<contextproperty name="RenderedLogMessage" layout="${message}" />
+		<contextproperty name="LogMessageTemplate" layout="${message:raw=true}" />
+		<contextproperty name="Logger" layout="${logger}" />
+		<contextproperty name="ThreadId" layout="${threadid}" />
+    </target>
   </targets>
   <rules>
     <!-- Set up the logger. -->

--- a/src/NLog.Raygun.sln
+++ b/src/NLog.Raygun.sln
@@ -16,6 +16,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{14CA5A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.Raygun.WebTestApp", "NLog.Raygun.WebTestApp\NLog.Raygun.WebTestApp.csproj", "{AFFD95DD-F82C-4AF5-840C-D05E8215031C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E8D8B67D-CFE6-4936-B343-18F8058B61ED}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/NLog.Raygun/NLog.Raygun.csproj
+++ b/src/NLog.Raygun/NLog.Raygun.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0;netstandard1.6</TargetFrameworks>
 
-    <Version>1.0.0</Version>
+    <Version>1.2.0</Version>
     <Title>NLog.Raygun</Title>
     <Product>NLog.Raygun</Product>
     <Company>Raygun</Company>
@@ -16,7 +16,6 @@
     <PackageLicenseUrl>https://raw.githubusercontent.com/MindscapeHQ/NLog.Raygun/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MindscapeHQ/NLog.Raygun</RepositoryUrl>
-    <PackageVersion>1.1.0</PackageVersion>
     <PackageIconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
@@ -26,6 +25,6 @@
     <PackageReference Include="Mindscape.Raygun4Net" Version="5.7.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-    <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="6.3.0" />
   </ItemGroup>
 </Project>

--- a/src/NLog.Raygun/UserCustomDictionary.cs
+++ b/src/NLog.Raygun/UserCustomDictionary.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NLog.Raygun
+{
+  class UserCustomDictionary : IDictionary, IDictionary<string, object>
+  {
+    private readonly IDictionary<string, object> _wrapped;
+
+    public UserCustomDictionary(IDictionary<string, object> dictionary)
+    {
+      _wrapped = dictionary;
+    }
+
+    object IDictionary.this[object key] { get => ValueSafeConverter(_wrapped[key.ToString()]); set => _wrapped[key.ToString()] = value; }
+    public object this[string key] { get => ValueSafeConverter(_wrapped[key]); set => _wrapped[key] = value; }
+
+    bool IDictionary.IsFixedSize => false;
+
+    public bool IsReadOnly => _wrapped.IsReadOnly;
+
+    ICollection IDictionary.Keys => (_wrapped.Keys as ICollection) ?? _wrapped.Keys.ToList();
+
+    ICollection IDictionary.Values => (_wrapped.Values as ICollection) ?? _wrapped.Values.ToList();
+
+    public ICollection<string> Keys => _wrapped.Keys;
+
+    public ICollection<object> Values => _wrapped.Values;
+
+    public int Count => _wrapped.Count;
+
+    bool ICollection.IsSynchronized => false;
+
+    object ICollection.SyncRoot => this;
+
+    void IDictionary.Add(object key, object value)
+    {
+      _wrapped.Add(key.ToString(), value);
+    }
+
+    public void Add(string key, object value)
+    {
+      _wrapped.Add(key, value);
+    }
+
+    public void Add(KeyValuePair<string, object> item)
+    {
+      _wrapped.Add(item);
+    }
+
+    public void Clear()
+    {
+      _wrapped.Clear();
+    }
+
+    bool IDictionary.Contains(object key)
+    {
+      return _wrapped.ContainsKey(key.ToString());
+    }
+
+    public bool Contains(KeyValuePair<string, object> item)
+    {
+      return _wrapped.Contains(item);
+    }
+
+    public bool ContainsKey(string key)
+    {
+      return _wrapped.ContainsKey(key);
+    }
+
+    public void CopyTo(Array array, int index)
+    {
+      if (array is KeyValuePair<string, object>[] validArray)
+        _wrapped.CopyTo(validArray, index);
+      else
+        (_wrapped as ICollection)?.CopyTo(array, index);
+    }
+
+    public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+    {
+      _wrapped.CopyTo(array, arrayIndex);
+    }
+
+    public void Remove(object key)
+    {
+      _wrapped.Remove(key.ToString());
+    }
+
+    public bool Remove(string key)
+    {
+      return _wrapped.Remove(key);
+    }
+
+    public bool Remove(KeyValuePair<string, object> item)
+    {
+      return _wrapped.Remove(item);
+    }
+
+    public bool TryGetValue(string key, out object value)
+    {
+      if (_wrapped.TryGetValue(key, out value))
+      {
+        value = ValueSafeConverter(value);
+        return true;
+      }
+      return false;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+      return GetEnumerator();
+    }
+
+    public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+    {
+      return new SafeDictionaryEnumerator(_wrapped.GetEnumerator());
+    }
+
+    IDictionaryEnumerator IDictionary.GetEnumerator()
+    {
+      return new SafeDictionaryEntryEnumerator(_wrapped.GetEnumerator());
+    }
+
+    class SafeDictionaryEnumerator : IEnumerator<KeyValuePair<string, object>>
+    {
+      readonly IEnumerator<KeyValuePair<string, object>> _wrapped;
+
+      public KeyValuePair<string, object> Current => new KeyValuePair<string, object>(_wrapped.Current.Key, ValueSafeConverter(_wrapped.Current.Value));
+
+      object IEnumerator.Current => Current;
+
+      public SafeDictionaryEnumerator(IEnumerator<KeyValuePair<string, object>> wrapped)
+      {
+        _wrapped = wrapped;
+      }
+
+      public void Dispose()
+      {
+        _wrapped.Dispose();
+      }
+
+      public bool MoveNext()
+      {
+        return _wrapped.MoveNext();
+      }
+
+      public void Reset()
+      {
+        _wrapped.Reset();
+      }
+    }
+
+    class SafeDictionaryEntryEnumerator : IDictionaryEnumerator
+    {
+      readonly IEnumerator<KeyValuePair<string, object>> _wrapped;
+
+      public DictionaryEntry Entry => new DictionaryEntry(_wrapped.Current.Key, ValueSafeConverter(_wrapped.Current.Value));
+
+      public object Key => _wrapped.Current.Key;
+
+      public object Value => ValueSafeConverter(_wrapped.Current.Value);
+
+      public object Current => Entry;
+
+      public SafeDictionaryEntryEnumerator(IEnumerator<KeyValuePair<string, object>> wrapped)
+      {
+        _wrapped = wrapped;
+      }
+
+      public bool MoveNext()
+      {
+        return _wrapped.MoveNext();
+      }
+
+      public void Reset()
+      {
+        _wrapped.Reset();
+      }
+    }
+
+    private static object ValueSafeConverter(object value)
+    {
+      try
+      {
+        if (Convert.GetTypeCode(value) != TypeCode.Object)
+          return value;
+        else
+          return value.ToString();
+      }
+      catch
+      {
+        return null;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Now possible to do this:

```xml
	<target name="RayGunTarget" type="RayGun" ApiKey="">
		<contextproperty name="RenderedLogMessage" layout="${message}" />
		<contextproperty name="LogMessageTemplate" layout="${message:raw=true}" />
		<contextproperty name="Logger" layout="${logger}" />
		<contextproperty name="ThreadId" layout="${threadid}" />
        </target>
```