### PR TITLE
[CR-300] Release breadcrumbs and context-properties support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NLog.Raygun
 A custom [NLog] target that will push exceptions to [Raygun].
 
 [NLog]: http://nlog-project.org/
-[Raygun]: http://raygun.io/
+[Raygun]: https://raygun.com/
 
 ## Configuration
 
@@ -44,8 +44,8 @@ Your `NLog.config` should look something like this:
   <targets>
     <!-- Set up the target (Avoid using async=true or AsyncWrapper) -->
 	<target 
-		name="RayGunTarget" 
-		type="RayGun" 
+		name="RaygunTarget" 
+		type="Raygun" 
 		ApiKey="" 
 		Tags="" 
 		IncludeEventProperties="true" 
@@ -67,7 +67,7 @@ Your `NLog.config` should look something like this:
   </targets>
   <rules>
     <!-- Set up the logger. -->
-    <logger name="*" minlevel="Error" writeTo="RayGunTarget" />
+    <logger name="*" minlevel="Error" writeTo="RaygunTarget" />
   </rules>
 </nlog>
 ```

--- a/src/NLog.Raygun.TestApp/NLog.config
+++ b/src/NLog.Raygun.TestApp/NLog.config
@@ -7,10 +7,11 @@
    -->
   <targets>
     <!-- add your targets here -->
-    <target name="RayGunTarget"
-            type="RayGun"
+    <target name="RaygunTarget"
+            type="Raygun"
             ApiKey=""
-            Tags=""
+            Tags="ConsoleApp"
+            IncludeBreadcrumbMessages="true"
             IgnoreFormFieldNames=""
             IgnoreCookieNames=""
             IgnoreServerVariableNames=""
@@ -18,10 +19,15 @@
             UseExecutingAssemblyVersion="false"
             ApplicationVersion="${assembly-version:NLog.Raygun.TestApp}"
             UserIdentityInfo="${windows-identity}"
-            layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}" />
+            layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}">
+      <contextproperty name="RenderedLogMessage" layout="${message}" />
+      <contextproperty name="LogMessageTemplate" layout="${message:raw=true}" />
+      <contextproperty name="Logger" layout="${logger}" />
+      <contextproperty name="ThreadId" layout="${threadid}" />
+    </target>
   </targets>
   <rules>
     <!-- add your logging rules here -->
-    <logger name="*" minlevel="Error" writeTo="RayGunTarget" />
+    <logger name="*" minlevel="Trace" writeTo="RaygunTarget" />
   </rules>
 </nlog>

--- a/src/NLog.Raygun.TestApp/Program.cs
+++ b/src/NLog.Raygun.TestApp/Program.cs
@@ -6,17 +6,20 @@ namespace NLog.Raygun.TestApp
   internal class Program
   {
     private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-    
+
     private static void Main(string[] args)
     {
-      Console.WriteLine("Sending Message to RayGun...");
+      AppDomain.CurrentDomain.UnhandledException += CatchUnhandledException;
 
-      Logger.Info("This is a test!");
+      // By default all log events are sent as Raygun error reports.
+      // However log events without an exception can be recorded as a breadcrumb for the next
+      // error report if `IncludeBreadcrumbMessages` is set to `true` in your Raygun target configuration.
+      Logger.Info("Hello world!");
 
       try
       {
-        var e = new Exception("Test Exception");
-        e.Data["Tags"] = new List<string> { "Tester123" };
+        var e = new Exception("A generic handled exception");
+        e.Data["Tags"] = new List<string> { "NonFatal" };
 
         throw e;
       }
@@ -25,8 +28,30 @@ namespace NLog.Raygun.TestApp
         Logger.Error(exception);
       }
 
-      Console.WriteLine("Finished...");
-      Console.Read();
+      PerformOperation();
+    }
+
+    private static void PerformOperation()
+    {
+      PerformUnsafeOperation();
+    }
+
+    private static void PerformUnsafeOperation()
+    {
+      var zero = 0;
+      var one = 1;
+
+      var result = one / zero;
+    }
+
+    private static void CatchUnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+      var exception = e.ExceptionObject as Exception;
+      exception.Data["Tags"] = new List<string> { "Fatal", "UnhandledException" };
+      Logger.Fatal(exception);
+
+      Console.WriteLine("A fatal error has occurred.\nPress any <Enter> to exit...");
+      while (Console.ReadKey().Key != ConsoleKey.Enter) {}
     }
   }
 }

--- a/src/NLog.Raygun.WebTestApp/Controllers/BaseController.cs
+++ b/src/NLog.Raygun.WebTestApp/Controllers/BaseController.cs
@@ -10,7 +10,7 @@ namespace NLog.Raygun.WebTestApp.Controllers
 
     static BaseController()
     {
-      ConfigurationItemFactory.Default.Targets.RegisterDefinition("RayGun", typeof(RayGunTarget));
+      ConfigurationItemFactory.Default.Targets.RegisterDefinition("Raygun", typeof(RaygunTarget));
       LogManager.ReconfigExistingLoggers();
     }
 

--- a/src/NLog.Raygun.WebTestApp/NLog.config
+++ b/src/NLog.Raygun.WebTestApp/NLog.config
@@ -11,19 +11,24 @@
   </extensions>
 
   <targets>
-    <target name="RayGunTarget"
-            type="RayGun"
+    <target name="RaygunTarget"
+            type="Raygun"
             ApiKey=""
-            Tags=""
+            Tags="WebApp"
             IgnoreFormFieldNames=""
             IgnoreCookieNames=""
             IgnoreServerVariableNames=""
             IgnoreHeaderNames=""
             UseExecutingAssemblyVersion="false"
             ApplicationVersion=""
-            layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}" />
+            layout="${uppercase:${level}} ${message} ${exception:format=ToString,StackTrace}${newline}">
+      <contextproperty name="RenderedLogMessage" layout="${message}" />
+      <contextproperty name="LogMessageTemplate" layout="${message:raw=true}" />
+      <contextproperty name="Logger" layout="${logger}" />
+      <contextproperty name="ThreadId" layout="${threadid}" />
+    </target>
   </targets>
   <rules>
-    <logger name="*" minlevel="Error" writeTo="RayGunTarget" />
+    <logger name="*" minlevel="Trace" writeTo="RaygunTarget" />
   </rules>
 </nlog>

--- a/src/NLog.Raygun/NLog.Raygun.csproj
+++ b/src/NLog.Raygun/NLog.Raygun.csproj
@@ -17,6 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/MindscapeHQ/NLog.Raygun</RepositoryUrl>
     <PackageIconUrl>https://app.raygun.com/Content/Images/nuget-icon.png</PackageIconUrl>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.5.11" />

--- a/src/NLog.Raygun/NLog.Raygun.csproj
+++ b/src/NLog.Raygun/NLog.Raygun.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0;netstandard1.6</TargetFrameworks>
 
-    <Version>1.2.0</Version>
+    <Version>2.0.0</Version>
     <Title>NLog.Raygun</Title>
     <Product>NLog.Raygun</Product>
     <Company>Raygun</Company>

--- a/src/NLog.Raygun/RaygunException.cs
+++ b/src/NLog.Raygun/RaygunException.cs
@@ -7,13 +7,11 @@ namespace NLog.Raygun
         public RaygunException(string message)
             : base(message)
         {
-
         }
 
         public RaygunException(string message, Exception innerException)
             : base(message, innerException)
         {
-            
         }
     }
 }


### PR DESCRIPTION
Major 2.0 release due to breaking changes.

Changes:
- Added breadcrumb support for .NET framework version
- Added unique user support for .NET Core version
- Added the ability to include NLog context property information with error reports
- Removed deprecated property `UseIdentityNameAsUserId`
- Updated the use of "Raygun" to the correct spelling (version breaking change)